### PR TITLE
[WSL] Update 5-build.mdx

### DIFF
--- a/content/docs/tutorial/5-build.mdx
+++ b/content/docs/tutorial/5-build.mdx
@@ -13,8 +13,8 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 2. Make sure that you have already run the following commands from the [system setup section](./2-setup#cargo-components).
 
 ```bash
-cargo install cargo-binstall
-cargo binstall cargo-component warg-cli wkg --locked --no-confirm --force
+cargo install cargo-binstall wkg
+cargo binstall cargo-component warg-cli --locked --no-confirm --force
 
 # Configure default registry
 wkg config --default-registry wa.dev


### PR DESCRIPTION
Builds wkg binary rather than install downloaded binary for compatibility with WSL2 Ubuntu LTS 24.04. 

`cargo binstall wkg` leads to
```
wkg config --default-registry wa.dev
wkg: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by wkg)
wkg: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by wkg)
```
Was able to run `wkg config --default-registry wa.dev` through `wasi-build  wasi-exec` afterwards. 