### PR TITLE
Update open-in-llm.tsx

### DIFF
--- a/components/open-in-llm.tsx
+++ b/components/open-in-llm.tsx
@@ -60,14 +60,14 @@ export const OpenInLLM = () => {
   // Function to create Claude URL
   const getClaudeUrl = () => {
     if (!mounted || typeof window === 'undefined') return '#';
-    const url = isIndexPage ? `${window.location.origin}/api/md/docs/index` : markdownUrl;
+    const url = isIndexPage ? `${window.location.origin}/docs` : currentUrl;
     return `https://claude.ai/new?q=${encodeURIComponent(`Read from ${url} so I can ask questions about it`)}`;
   };
 
   // Function to create ChatGPT URL
   const getChatGPTUrl = () => {
     if (!mounted || typeof window === 'undefined') return '#';
-    const url = isIndexPage ? `${window.location.origin}/api/md/docs/index` : markdownUrl;
+    const url = isIndexPage ? `${window.location.origin}/docs` : currentUrl;
     return `https://chatgpt.com/?hints=search&q=${encodeURIComponent(`Read from ${url} so I can ask questions about it`)}`;
   };
 


### PR DESCRIPTION
Update Claude and chatgpt links so they do not append `.md`. Claude and chatgpt can only open pages using their webfetch tools, not directly from URLs, so the actual site page is more accurate for them than raw markdown. 